### PR TITLE
Make return values of Graphic methods optionally be undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@ The log below details the changes during development of this version:
 * 2025-03-27: Draft 0 made public.
 * 2025-04-23: Fix in JSON-schemas: Changed `main` property in Graphics manifest to be **mandatory**.
   (Before, it was defined as mandatory in the specification document, but not in the JSON-schemas.)
+* 2025-xx-xx: Change return values of Graphic methods to optionally be `undefined`.
+  (An `undefined` value should be treated as `{ code: 200 }`)

--- a/v1-draft-0/specification/docs/Specification.md
+++ b/v1-draft-0/specification/docs/Specification.md
@@ -134,10 +134,11 @@ Depending on the rendering capabilities (defined in the Manifest file), a Graphi
 To describe the functions in this document, the Typescript interface notation is used. For simplicity, we omit the indication
 that vendor-specific fields can be included in both request and response payloads.
 For the 'action' methods (`playAction()`, `stopAction()`, `updateAction()` and `customAction()`), a Promise MUST be returned that
-resolves to an `ReturnPayload` object containing the following fields:
+resolves to `undefined` or to an `ReturnPayload` object containing the following fields:
 * `code`: a number that corresponds to an HTTP status code (2xx indicates a successful result, 4xx and 5xx indicate an error).
 * `message`: an optional human-readable message that corresponds to the `code`.
 * `result`: an optional Graphics-specific response object.
+If the returned Promise resolves to `undefined`, it should be treated as a `{ code: 200 }`.
 
 Similarly, for simplicity reasons, we omit these three fields in the description of the functions below.
 In [Typescript interface](#typescript-interface-for-graphic), the full interface is provided.

--- a/v1-draft-0/typescript-definitions/src/apis/graphicsAPI.ts
+++ b/v1-draft-0/typescript-definitions/src/apis/graphicsAPI.ts
@@ -30,7 +30,7 @@ export interface Graphic {
       /** Whether the rendering is done in realtime or non-realtime */
       renderType: "realtime" | "non-realtime";
     } & VendorExtend
-  ) => Promise<ReturnPayload>;
+  ) => Promise<ReturnPayload | undefined>;
 
   /**
    * Called by the Renderer to force the Graphic to terminate/dispose/clear any loaded resources.
@@ -44,7 +44,7 @@ export interface Graphic {
       /** The data send here is defined in the manifest "schema". */
       data: unknown;
     } & VendorExtend
-  ) => Promise<ReturnPayload>;
+  ) => Promise<ReturnPayload | undefined>;
 
   /** This is called when user calls the "play" action. */
   playAction: (
@@ -61,13 +61,15 @@ export interface Graphic {
   /** This is called when user calls the "stop" action. */
   stopAction: (
     params: { skipAnimation: boolean } & VendorExtend
-  ) => Promise<ReturnPayload>;
+  ) => Promise<ReturnPayload | undefined>;
 
   /**
    * Called by the Renderer to invoke an Action on the Graphic
    * @returns The return value of the invoked method (vendor-specific)
    */
-  customAction: (params: ActionInvokeParams) => Promise<ReturnPayload>;
+  customAction: (
+    params: ActionInvokeParams
+  ) => Promise<ReturnPayload | undefined>;
 
   /**
    * If the Graphic supports non-realtime rendering, this is called to make the graphic jump to a certain point in time.
@@ -75,7 +77,7 @@ export interface Graphic {
    */
   goToTime: (
     params: { timestamp: number } & VendorExtend
-  ) => Promise<ReturnPayload>;
+  ) => Promise<ReturnPayload | undefined>;
 
   /**
    * If the Graphic supports non-realtime rendering, this is called to schedule actions to be invoked at a certain point in time.
@@ -109,6 +111,5 @@ export interface Graphic {
             } & VendorExtend);
       }[];
     } & VendorExtend
-  ) => Promise<EmptyPayload>;
+  ) => Promise<EmptyPayload | undefined>;
 }
-

--- a/v1-draft-0/typescript-definitions/src/definitions/types.ts
+++ b/v1-draft-0/typescript-definitions/src/definitions/types.ts
@@ -42,7 +42,7 @@ export type ActionInvokeParams = {
   payload: unknown;
 } & VendorExtend;
 
-export type PlayActionReturnPayload = ReturnPayload & {
+export type PlayActionReturnPayload = (ReturnPayload | {}) & {
   /** The resulting step from a PlayAction */
-  currentStep: number
-}
+  currentStep: number;
+};


### PR DESCRIPTION
## Background

This is a suggestion from me.

In the spirit of simplifying implementation for the Graphics developers, I find that requiring all methods to return a `ReturnPayload`  (or a variation thereof) to be somewhat tedious.

## About this PR

This PR makes the return values for the methods of a Graphic be optional.

With the exception of `playAction`, which is now allowed to return `{ currentStep: 1 }` (which should be functionally equivalent to `{ code: 200, currentStep: 1 }`.


This PR will be reviewed in the working group before being merged.