### PR TITLE
Include optional property skipAnimation in all actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,5 @@ The log below details the changes during development of this version:
   Before, the `data`-payload was only sent using the `updateData()` method. Now it must be sent on `load()` as well.
 * 2025-05-16: Change return values of Graphic methods to optionally be `undefined`.
   (An `undefined` value should be treated as `{ code: 200 }`)
+* 2025-xx-xx: Add optional `skipAnimation` argument to `updateAction` and `customAction`.
+  Before, it was only included in `playAction` and `stopAction`.

--- a/v1-draft-0/typescript-definitions/src/apis/graphicsAPI.ts
+++ b/v1-draft-0/typescript-definitions/src/apis/graphicsAPI.ts
@@ -50,6 +50,8 @@ export interface Graphic {
     params: {
       /** The data send here is defined in the manifest "schema". Note: This data MUST HAVE the same type as the `data` argument in the load method.  */
       data: unknown;
+      /** If true, skips animation (defaults to false) */
+      skipAnimation?: boolean;
     } & VendorExtend
   ) => Promise<ReturnPayload | undefined>;
 
@@ -61,13 +63,16 @@ export interface Graphic {
       /** Jump to a specific step/segment (defaults to undefined) */
       goto: number;
       /** If true, skips animation (defaults to false) */
-      skipAnimation: boolean;
+      skipAnimation?: boolean;
     } & VendorExtend
   ) => Promise<PlayActionReturnPayload>;
 
   /** This is called when user calls the "stop" action. */
   stopAction: (
-    params: { skipAnimation: boolean } & VendorExtend
+    params: {
+      /** If true, skips animation (defaults to false) */
+      skipAnimation?: boolean
+    } & VendorExtend
   ) => Promise<ReturnPayload | undefined>;
 
   /**

--- a/v1-draft-0/typescript-definitions/src/definitions/types.ts
+++ b/v1-draft-0/typescript-definitions/src/definitions/types.ts
@@ -40,6 +40,9 @@ export type ActionInvokeParams = {
   id: string;
   /** Params to send into the method */
   payload: unknown;
+
+  /** If true, skips animation (defaults to false) */
+  skipAnimation?: boolean;
 } & VendorExtend;
 
 export type PlayActionReturnPayload = (ReturnPayload | {}) & {


### PR DESCRIPTION
## Background

This suggestion comes from myself.

As I was working on some example graphics, I realized that I would like the `skipAnimation` to be present generically, ie for all actions, not just `playAction` and `stopAction` as it is today.

## About this PR

This PR adds `skipAnimation` argument to `updateAction` and `customAction`.

This PR will be presented to the Ograf working group and discussed there before being merged.