### PR TITLE
feat: add accessToPublicInternet to RenderCharacteristics

### DIFF
--- a/v1/specification/docs/Specification.md
+++ b/v1/specification/docs/Specification.md
@@ -137,6 +137,7 @@ The RenderRequirement object contains the following fields:
 | resolution.width  | NumberConstraint |          |         | Specifies renderer width resolution requirement. |
 | resolution.height | NumberConstraint |          |         | Specifies renderer height resolution requirement. |
 | frameRate         | NumberConstraint |          |         | Specifies renderer frameRate requirement. |
+| accessToPublicInternet | BooleanConstraint |          |    | Specifies requirement on whether the renderer has access to the public internet or not. |
 
 ##### NumberConstraint
 
@@ -161,6 +162,18 @@ It contains the following fields:
 |-------------------|------------------|:--------:|:-------:|-----------------------------------------------------------|
 | exact             | string           |          |         | A string specifying a specific, required, value the property must have to be considered acceptable. |
 | ideal             | string, string[] |          |         | A string (or an array of strings), specifying ideal values for the property. If possible, one of the listed values will be used, but if it's not possible, the user agent will use the closest possible match. |
+
+
+##### BooleanConstraint
+
+A BooleanConstraint is an object that describes a constraints for a boolean value.
+(This is inspired by https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean)
+It contains the following fields:
+
+| Field             | Type             | Required | Default | Description                                               |
+|-------------------|------------------|:--------:|:-------:|-----------------------------------------------------------|
+| exact             | boolean           |          |         | A boolean specifying a specific, required, value the property must have to be considered acceptable. |
+| ideal             | boolean           |          |         | A boolean specifying an ideal value for the property. If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match. |
 
 #### Vendor-specific fields
 

--- a/v1/specification/json-schemas/graphics/schema.json
+++ b/v1/specification/json-schemas/graphics/schema.json
@@ -99,6 +99,10 @@
                     "frameRate": {
                         "description": "If set, specifies requirements for frame rate of the Renderer. Example: 60 fps",
                         "$ref": "https://ograf.ebu.io/v1/specification/json-schemas/lib/constraints/number.json"
+                    },
+                    "accessToPublicInternet": {
+                        "description": "If set, specifies requirement on whether the renderer has access to the public internet or not.",
+                        "$ref": "https://ograf.ebu.io/v1/specification/json-schemas/lib/constraints/boolean.json"
                     }
 
                 },

--- a/v1/specification/json-schemas/lib/constraints/boolean.json
+++ b/v1/specification/json-schemas/lib/constraints/boolean.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://ograf.ebu.io/v1/specification/json-schemas/lib/constraints/boolean.json",
+    "type": "object",
+    "description": "The boolean constraint is used to specify a constraint for a boolean property. (Inspired by https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean)",
+    "properties": {
+        "exact": {
+            "description": "A boolean specifying a specific, required, value the property must have to be considered acceptable.",
+            "type": "boolean"
+        },
+        "ideal": {
+            "description": "A boolean specifying an ideal value for the property. If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.",
+            "type": "boolean"
+        }
+    },
+    "patternProperties": {
+        "^v_.*": {}
+    },
+    "additionalProperties": false
+}

--- a/v1/typescript-definitions/src/definitions/render.ts
+++ b/v1/typescript-definitions/src/definitions/render.ts
@@ -12,9 +12,11 @@ export type RenderCharacteristics = {
   /** Which frameRate the renderer will be rendering in. Examples: 50, 60, 29.97 */
   frameRate?: number;
 
+  /** Whether the renderer has access to the public internet (so the graphic can fetch resources) */
+  accessToPublicInternet?: boolean
+
   // Ideas for future:
   // webcamInputs
-  // accessToPublicInternet?: boolean // Whether the renderer has access to the public internet (so the graphic can fetch resources)
   // keyer?: boolean; //
 
 } & VendorExtend;

--- a/v1/typescript-definitions/src/generated/graphics-manifest.ts
+++ b/v1/typescript-definitions/src/generated/graphics-manifest.ts
@@ -524,6 +524,7 @@ export interface HttpsOgrafEbuIoV1SpecificationJsonSchemasGraphicsSchemaJson {
       [k: string]: unknown;
     };
     frameRate?: HttpsOgrafEbuIoV1SpecificationJsonSchemasLibConstraintsNumberJson1;
+    accessToPublicInternet?: HttpsOgrafEbuIoV1SpecificationJsonSchemasLibConstraintsBooleanJson;
     /**
      * This interface was referenced by `undefined`'s JSON-Schema definition
      * via the `patternProperty` "^v_.*".
@@ -613,6 +614,24 @@ export interface HttpsOgrafEbuIoV1SpecificationJsonSchemasLibConstraintsNumberJs
    * via the `patternProperty` "^v_.*".
    *
    * This interface was referenced by `HttpsOgrafEbuIoV1SpecificationJsonSchemasLibConstraintsNumberJson1`'s JSON-Schema definition
+   * via the `patternProperty` "^v_.*".
+   */
+  [k: `v_${string}`]: unknown;
+}
+/**
+ * If set, specifies requirement on whether the renderer has access to the public internet or not.
+ */
+export interface HttpsOgrafEbuIoV1SpecificationJsonSchemasLibConstraintsBooleanJson {
+  /**
+   * A boolean specifying a specific, required, value the property must have to be considered acceptable.
+   */
+  exact?: boolean;
+  /**
+   * A boolean specifying an ideal value for the property. If possible, this value will be used, but if it's not possible, the user agent will use the closest possible match.
+   */
+  ideal?: boolean;
+  /**
+   * This interface was referenced by `HttpsOgrafEbuIoV1SpecificationJsonSchemasLibConstraintsBooleanJson`'s JSON-Schema definition
    * via the `patternProperty` "^v_.*".
    */
   [k: `v_${string}`]: unknown;


### PR DESCRIPTION
As per the discussion at the Working Group meeting at 2025-06-11, this PR adds the property `accessToPublicInternet` to `RenderCharacteristics` and `manifest.renderRequirements`.