### PR TITLE
fix: rename  `code` and `message` in return data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The log below details the changes during development of this version:
 * 2025-05-16: Add `data` argument to the `load` method.
   Before, the `data`-payload was only sent using the `updateData()` method. Now it must be sent on `load()` as well.
 * 2025-05-16: Change return values of Graphic methods to optionally be `undefined`.
-  (An `undefined` value should be treated as `{ code: 200 }`)
+  (An `undefined` value should be treated as `{ statusCode: 200 }`)
 * 2025-06-09: Rename the "v1-draft-0" to "v1" in preparation for the first release.
 * 2025-06-13: Add requirement on manifest file name.
   The manifest file must now have the suffix `".ograf"`.

--- a/v1/specification/docs/Specification.md
+++ b/v1/specification/docs/Specification.md
@@ -181,10 +181,10 @@ To describe the functions in this document, the Typescript interface notation is
 that vendor-specific fields can be included in both request and response payloads.
 For the 'action' methods (`playAction()`, `stopAction()`, `updateAction()` and `customAction()`), a Promise MUST be returned that
 resolves to `undefined` or to an `ReturnPayload` object containing the following fields:
-* `code`: a number that corresponds to an HTTP status code (2xx indicates a successful result, 4xx and 5xx indicate an error).
-* `message`: an optional human-readable message that corresponds to the `code`.
+* `statusCode`: a number that corresponds to an HTTP status code (2xx indicates a successful result, 4xx and 5xx indicate an error).
+* `statusMessage`: an optional human-readable message that corresponds to the `statusCode`.
 * `result`: an optional Graphics-specific response object.
-If the returned Promise resolves to `undefined`, it should be treated as a `{ code: 200 }`.
+If the returned Promise resolves to `undefined`, it should be treated as a `{ statusCode: 200 }`.
 
 Similarly, for simplicity reasons, we omit these three fields in the description of the functions below.
 In [Typescript interface](#typescript-interface-for-graphic), the full interface is provided.
@@ -287,18 +287,18 @@ class Graphic extends HTMLElement {
   }
   async playAction({ delta: number, goto: number, skipAnimation: boolean }) {
     // Play the Graphic according to the incoming params
-    return {code: 200, message: 'OK', currentStep}
+    return {statusCode: 200, statusMessage: 'OK', currentStep}
   }
   async stopAction({ skipAnimation: boolean }) {
     // Stop the Graphic, with or without animation
-    return {code: 200, message: 'OK'}
+    return {statusCode: 200, statusMessage: 'OK'}
   }
   async updateAction({ data: { name: string } }) {
     // Update the state of the Graphic
-    return {code: 200, message: 'OK'}
+    return {statusCode: 200, statusMessage: 'OK'}
   }
   async customAction({ id: string, payload: any}) {
-    return {code: 400, message: 'No custom actions supported'}
+    return {statusCode: 400, statusMessage: 'No custom actions supported'}
   }
 }
 

--- a/v1/typescript-definitions/src/definitions/types.ts
+++ b/v1/typescript-definitions/src/definitions/types.ts
@@ -10,7 +10,7 @@ export type ReturnPayload = {
    */
   statusCode: number;
   /**
-   * (Optional) A human-readable message to help understand the status code.
+   * (Optional) A human-readable message to help understand the statusCode.
    */
   statusMessage?: string;
 } & VendorExtend;


### PR DESCRIPTION
There is a discrepancy between the specification.md and typescript files regarding the naming in the return data.

This PR renames  `code` and `message` to `statusCode` and `statusMessage` in Specification.md, to align with what's in the typescript types.

We'll discuss this PR on the next working group meeting to decide which of the two naming conventions to go for.