### PR TITLE
ServerAPI: Remove GraphicId in favor for GraphicInstanceId

### DIFF
--- a/v1/specification/open-api/server-api.yaml
+++ b/v1/specification/open-api/server-api.yaml
@@ -439,9 +439,9 @@ paths:
           required: true
         - in: query
           name: graphicTarget
-          description: "The Graphic to target with the command"
+          description: "The Graphic to target with the command (graphicInstanceId)"
           schema:
-            $ref: "#/components/schemas/GraphicTarget"
+            $ref: "#/components/schemas/GraphicInstanceId"
           required: true
       requestBody:
         required: true
@@ -505,9 +505,9 @@ paths:
           required: true
         - in: query
           name: graphicTarget
-          description: "The Graphic to target with the command"
+          description: "The Graphic to target with the command (graphicInstanceId)"
           schema:
-            $ref: "#/components/schemas/GraphicTarget"
+            $ref: "#/components/schemas/GraphicInstanceId"
           required: true
       requestBody:
         required: true
@@ -578,9 +578,9 @@ paths:
           required: true
         - in: query
           name: graphicTarget
-          description: "The Graphic to target with the command"
+          description: "The Graphic to target with the command (graphicInstanceId)"
           schema:
-            $ref: "#/components/schemas/GraphicTarget"
+            $ref: "#/components/schemas/GraphicInstanceId"
           required: true
       requestBody:
         required: true
@@ -645,9 +645,9 @@ paths:
           required: true
         - in: query
           name: graphicTarget
-          description: "The Graphic to target with the command"
+          description: "The Graphic to target with the command (graphicInstanceId)"
           schema:
-            $ref: "#/components/schemas/GraphicTarget"
+            $ref: "#/components/schemas/GraphicInstanceId"
           required: true
       requestBody:
         required: true
@@ -712,9 +712,9 @@ paths:
           required: true
         - in: query
           name: graphicTarget
-          description: "The Graphic to target with the command"
+          description: "The Graphic to target with the command (graphicInstanceId)"
           schema:
-            $ref: "#/components/schemas/GraphicTarget"
+            $ref: "#/components/schemas/GraphicInstanceId"
           required: true
       requestBody:
         required: true
@@ -787,9 +787,9 @@ paths:
           required: true
         - in: query
           name: graphicTarget
-          description: "The Graphic to target with the command"
+          description: "The Graphic to target with the command (graphicInstanceId)"
           schema:
-            $ref: "#/components/schemas/GraphicTarget"
+            $ref: "#/components/schemas/GraphicInstanceId"
           required: true
       requestBody:
         required: true
@@ -971,16 +971,6 @@ components:
         graphicInstanceId:
           description: "(Optional) If set, will only affect a specific GraphicInstance"
           type: string
-    GraphicTarget:
-      description: "If set, apply filters to which GraphicInstances to affect. If no filters are defined, ALL graphics will be cleared. If multiple filters are defined, only instances that match all filters will be affected."
-      type: object
-      properties:
-        graphicId:
-          description: "(Optional) If set, will only affect GraphicInstances of a certain Graphic id and version"
-          $ref: "#/components/schemas/GraphicId"
-        graphicInstanceId:
-          description: "(Optional) If set, will only affect a specific GraphicInstance"
-          $ref: "#/components/schemas/GraphicInstanceId"
      # Ids
     RendererId:
       description: "ID of the Renderer"
@@ -994,7 +984,7 @@ components:
       type: string
       example: "simple-l3rd"
     GraphicInstanceId:
-      description: "ID of the GraphicInstance"
+      description: "ID of an GraphicInstance. A GraphicInstance is a specific instance of a Graphic that is loaded onto a RenderTarget."
       type: string
       example: "graphic-instance-0"
     # Objects


### PR DESCRIPTION
This PR is a suggestion to be discussed in the Working Group.

Remove the option to address a graphic by its id, in favor for a GraphicInstanceId only.