### PR TITLE
Clarify Web Component Interface section

### DIFF
--- a/v1/typescript-definitions/src/apis/graphicsAPI.ts
+++ b/v1/typescript-definitions/src/apis/graphicsAPI.ts
@@ -43,7 +43,7 @@ export interface Graphic {
    * Called by the Renderer to force the Graphic to terminate/dispose/clear any loaded resources.
    * This is called after the Renderer has unloaded the Graphic from the DOM.
    */
-  dispose: (params: EmptyParams) => Promise<ReturnPayload>;
+  dispose: (params: EmptyParams) => Promise<ReturnPayload | undefined>;
 
   /** This is called whenever user send a new data payload. */
   updateAction: (

--- a/v1/typescript-definitions/src/definitions/types.ts
+++ b/v1/typescript-definitions/src/definitions/types.ts
@@ -40,9 +40,6 @@ export type ActionInvokeParams = {
   id: string;
   /** Params to send into the method */
   payload: unknown;
-
-  /** If true, skips animation (defaults to false) */
-  skipAnimation?: boolean;
 } & VendorExtend;
 
 export type PlayActionReturnPayload = (ReturnPayload | {}) & {


### PR DESCRIPTION
Rewrote the section about the Web Component Interface:
- reuse typescript definition for each function
- be more expliciet about the promises
- clarify the target step in the playAction() function
- various smaller rewrites that should improve the level of understanding when reading the spec

Other things to mention:
- I integrated the work proposed in https://github.com/ebu/ograf/pull/14 into this pull request. When this one gets merged, the latter should be rejected.
- I changed two things in the typescript definitions:
  - added `undefined` as a possible value in the Promise of `dispose()`
  - removed `skipAnimation` field from the `customAction()` function as this was never in the text