### PR TITLE
Add docs for skipAnimation, re-add skipAnimation in customAction

### DIFF
--- a/v1/specification/docs/Specification.md
+++ b/v1/specification/docs/Specification.md
@@ -333,6 +333,10 @@ The `updateAction()` function is called by the Renderer to update one or more fi
 Graphic. The `data` field contains a (potentially partial) update of the internal state of the Graphic and follows the
 model described in the Manifest using the `schema` field.
 
+The `skipAnimation` field indicates whether the Graphic should update with or without animation.
+When not provided, the `skipAnimation` field defaults to `false`. The Graphic MUST skip the animation when
+`skipAnimation` is set to `true`.
+
 The returned Promise MUST resolve after the execution of the update.
 
 
@@ -342,6 +346,7 @@ customAction: (
   params: {
     id: string;
     payload: unknown;
+    skipAnimation?: boolean;
   } & VendorExtend
 ) => Promise<ReturnPayload | undefined>;
 ```
@@ -350,7 +355,12 @@ correspond to an `id` of an Action that is defined in the Manifest file, inside 
 `payload` field is the described in the corresponding Action inside the Manifest file. The returned Promise MUST
 resolve when the action is executed.
 
-<br>
+The `skipAnimation` field indicates whether the Graphic should disappear with or without animation.
+When not provided, the `skipAnimation` field defaults to `false`. The Graphic MUST skip the animation when
+`skipAnimation` is set to `true`.
+
+---
+
 Additionally, every non-real-time Graphic MUST implement the following functions.
 
 #### goToTime()

--- a/v1/typescript-definitions/src/definitions/types.ts
+++ b/v1/typescript-definitions/src/definitions/types.ts
@@ -40,6 +40,9 @@ export type ActionInvokeParams = {
   id: string;
   /** Params to send into the method */
   payload: unknown;
+
+  /** If true, skips animation (defaults to false) */
+  skipAnimation?: boolean;
 } & VendorExtend;
 
 export type PlayActionReturnPayload = ReturnPayload & {


### PR DESCRIPTION
Background:

The `skipAnimation` was initially added to all actions in PR #8, however I had forgotten to update the specification document in that PR.

Then (due to it missing in the specification document), `skipAnimation` was removed from `customAction()` in PR #34.

This PR

* Adds a missing definition of the `skipAnimation` property in `updateAction()`, in the specification document.
* Re-adds the previously removed `skipAnimation` in `customAction()`.

Motivation:

To expand on #8, I think it would be beneficial if the skipAnimation property is present for _**all**_ methods (excluding the non-realtime ones). 

For example, a Graphics Controller can then easilly display a _graphics preview_ to a user by simply including `skipAnimation: true` to all commands on a "preview channel".