### PR TITLE
server-api/CORS

### DIFF
--- a/v1/specification/docs/Specification_Server_API.md
+++ b/v1/specification/docs/Specification_Server_API.md
@@ -25,3 +25,14 @@ The OGraf Server API is defined as an [OpenAPI](https://www.openapis.org/) defin
 * The current version of the Server API doesn't specify any security measures.
 * It is up to the vendor to ensure security/authentication.
 * Future versions of the Server API may include optional/recommended security/authentication methods.
+
+### CORS (optional)
+
+To ensure that web-based Graphics Controllers can access the API, the Server MAY add the following [CORS](http://www.w3.org/TR/cors) headers to all responses:
+
+```yaml
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, PUT, POST, HEAD, OPTIONS, DELETE
+Access-Control-Allow-Headers: Content-Type, Accept
+Access-Control-Max-Age: 3600
+```


### PR DESCRIPTION
This PR adds a note about including optional CORS headers.

(The headers are based on https://specs.amwa.tv/is-04/releases/v1.2.2/docs/2.3._APIs_-_Server_Side_Implementation_Notes.html#cross-origin-resource-sharing-cors )