### PR TITLE
Add hidden property to schema properties (Issue #46)

### DIFF
--- a/v1/examples/minimal/minimal.ograf.json
+++ b/v1/examples/minimal/minimal.ograf.json
@@ -14,7 +14,8 @@
                 "type": "string",
                 "default": "Hello World!",
                 "gddType": "color-rrggbb",
-                "pattern": "^#[0-9a-f]{6}$"
+                "pattern": "^#[0-9a-f]{6}$",
+                "hidden": true
             }
         }
     }

--- a/v1/specification/docs/Specification.md
+++ b/v1/specification/docs/Specification.md
@@ -70,13 +70,12 @@ It consists of the following fields:
 | customActions       | Action[]           |          |         | An array of `Action` objects. They correspond to the custom actions that can be invoked on the Graphic. See below for details about the fields inside an `Action`.    |
 | supportsRealTime    | boolean            |    X     |         | Indicates whether the Graphic supports real-time rendering.                                                                                                        |
 | supportsNonRealTime | boolean            |    X     |         | Indicates whether the Graphic supports non-real-time rendering. If true, the Graphic MUST implement the non-real-time functions `goToTime()` and `setActionsSchedule()`.                 |
-| schema              | object             |          |         | The JSON schema definition for the `data` argument to the `load()` and `updateAction()` methods. This schema can be seen as the (public) state model of the Graphic.                   |
+| schema              | object             |          |         | The JSON schema definition for the `data` argument to the `load()` and `updateAction()` methods. This schema can be seen as the (public) state model of the Graphic. Properties in this schema MAY include an optional `hidden` (boolean) attribute; when `hidden` is true, the property's value SHOULD NOT be included when building a display name or label for the Graphic in a GUI (e.g. in playout or automation UIs).                   |
 | stepCount           | integer            |          |    1    | The number of steps a Graphic consists of. If the Graphic is simply triggered by a play, then a stop, this is considered a stepCount of 1 (which is the default behavior if left undefined). A value of -1 indicates that a Graphic has a dynamic or unknown number of steps. |
 | renderRequirements  | RenderRequirement[]|          |         | A list of requirements that this Graphic has for the rendering environment. At least one of the requirements must be met for the graphic to be expected to work.   |
 
 There MAY be multiple manifest files in a folder. In the case of multiple manifest files, they will be interpreted as multiple, independent Graphics.
 This can be useful for example when having a package of multiple OGraf graphics, which then might share resources such as images, fonts, etc.
-
 #### Real-time vs. non-real-time
 
 Real-time rendering of a Graphic means that the Graphic is animated at real-time speed, typically in the context of live TV.

--- a/v1/specification/json-schemas/gdd/README.md
+++ b/v1/specification/json-schemas/gdd/README.md
@@ -166,10 +166,10 @@ All properties share these definitions: ([JSON-schema definition](https://json-s
   "label": string, // [Optional] Short label to name the property
   "description": string, // [Optional] Longer description of the property
   "gddType": string, // [Optional unless required by GDD Type] A string containing the GDD Type name, see below
-  "gddOptions": object // [Optional unless required by GDD Type] An object containing options for a certain GDD Type, see below
+  "gddOptions": object, // [Optional unless required by GDD Type] An object containing options for a certain GDD Type, see below
+  "hidden": boolean // [Optional] When true, exclude this property's value when building a label/display name for the graphic in a GUI. Default false.
 }
 ```
-
 #### The `type` property
 
 In the standard JSON-schema definition, the `type` property is allowed to be either a string or an array containing any combination of the basic types `"boolean"`, `"string"`, `"number"`, `"integer"`, `"array"`, `"object"` or `"null"`.

--- a/v1/specification/json-schemas/gdd/object.json
+++ b/v1/specification/json-schemas/gdd/object.json
@@ -19,6 +19,10 @@
     },
     "gddOptions": {
       "type": "object"
+    },
+    "hidden": {
+      "type": "boolean",
+      "description": "When true, the value of this property SHOULD NOT be included when labelling the graphic in a GUI (e.g. in playout or automation UIs). Default is false. Used to keep labels concise by excluding technical or less meaningful fields."
     }
   },
   "required": ["type"],

--- a/v1/typescript-definitions/scripts/generate-types.js
+++ b/v1/typescript-definitions/scripts/generate-types.js
@@ -45,6 +45,8 @@ async function saveFile(savePath, contents) {
   // The ^v_.* are generated as [k: string]: unknown, fix that:
   contents = contents.replaceAll(/(v_.+\n.*\n[ \t]+)(\[k: string\]: unknown)/g, '$1[k: `v_${string}`]: unknown')
 
+  // GDD object: generator does not emit optional props from $ref when allOf is used; add hidden so it appears like gddType/gddOptions
+  contents = contents.replace(/(gddOptions\?: \{\s*\[k: string\]: unknown;\s*\};)\n(    \[k: string\]: unknown;)/,"$1\n    hidden?: boolean;\n$2");
 
   // Replace contents in case of using localhost during testing:
   contents = contents.replaceAll('HttpLocalhost8080', 'HttpsOgrafEbuIo')

--- a/v1/typescript-definitions/src/generated/graphics-manifest.ts
+++ b/v1/typescript-definitions/src/generated/graphics-manifest.ts
@@ -13,6 +13,7 @@ export type HttpsOgrafEbuIoV1SpecificationJsonSchemasGddObjectJson = CoreAndVali
     gddOptions?: {
       [k: string]: unknown;
     };
+    hidden?: boolean;
     [k: string]: unknown;
   };
 export type CoreAndValidationSpecificationsMetaSchema = CoreVocabularyMetaSchema &


### PR DESCRIPTION
Schema properties can now set hidden: true so their value is excluded when building a display name/label for the graphic in GUIs (e.g. playout, automation). Default is false for backwards compatibility. Meeting 2026-02-18.