### PR TITLE
Add optional thumbnails to graphics manifest (Issue #20)

### DIFF
--- a/v1/specification/docs/Specification.md
+++ b/v1/specification/docs/Specification.md
@@ -73,6 +73,7 @@ It consists of the following fields:
 | schema              | object             |          |         | The JSON schema definition for the `data` argument to the `load()` and `updateAction()` methods. This schema can be seen as the (public) state model of the Graphic.                   |
 | stepCount           | integer            |          |    1    | The number of steps a Graphic consists of. If the Graphic is simply triggered by a play, then a stop, this is considered a stepCount of 1 (which is the default behavior if left undefined). A value of -1 indicates that a Graphic has a dynamic or unknown number of steps. |
 | renderRequirements  | RenderRequirement[]|          |         | A list of requirements that this Graphic has for the rendering environment. At least one of the requirements must be met for the graphic to be expected to work.   |
+| thumbnails          | Thumbnail[]        |          |         | Optional array of thumbnail entries. Each entry has `file` (path to image; PNG, JPG, GIF, or webp) and optionally `resolution` (object with `width` and `height` in pixels). |
 
 There MAY be multiple manifest files in a folder. In the case of multiple manifest files, they will be interpreted as multiple, independent Graphics.
 This can be useful for example when having a package of multiple OGraf graphics, which then might share resources such as images, fonts, etc.

--- a/v1/specification/json-schemas/graphics/schema.json
+++ b/v1/specification/json-schemas/graphics/schema.json
@@ -112,6 +112,41 @@
                 },
                 "additionalProperties": false
             }
+        },
+        "thumbnails": {
+            "description": "Optional list of thumbnail images for the Graphic. Each entry references an image file (PNG, JPG, GIF, or webp) and may specify its resolution so UIs can choose or scale appropriately.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "file": {
+                        "type": "string",
+                        "description": "Path to the image file, relative to the manifest or absolute. Allowed formats: PNG, JPG, GIF, webp."
+                    },
+                    "resolution": {
+                        "type": "object",
+                        "description": "Resolution of the image in pixels. When present, the UI can derive aspect ratio (e.g. width/height) and choose or scale the thumbnail appropriately.",
+                        "properties": {
+                            "width": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Width in pixels."
+                            },
+                            "height": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Height in pixels."
+                            }
+                        },
+                        "required": ["width", "height"]
+                    }
+                },
+                "required": ["file"],
+                "patternProperties": {
+                    "^v_.*": {}
+                },
+                "additionalProperties": false
+            }
         }
     },
     "required": [

--- a/v1/typescript-definitions/src/generated/graphics-manifest.ts
+++ b/v1/typescript-definitions/src/generated/graphics-manifest.ts
@@ -530,6 +530,34 @@ export interface HttpsOgrafEbuIoV1SpecificationJsonSchemasGraphicsSchemaJson {
     [k: `v_${string}`]: unknown;
   }[];
   /**
+   * Optional list of thumbnail images for the Graphic. Each entry references an image file (PNG, JPG, GIF, or webp) and may specify its resolution so UIs can choose or scale appropriately.
+   */
+  thumbnails?: {
+    /**
+     * Path to the image file, relative to the manifest or absolute. Allowed formats: PNG, JPG, GIF, webp.
+     */
+    file: string;
+    /**
+     * Resolution of the image in pixels. When present, the UI can derive aspect ratio (e.g. width/height) and choose or scale the thumbnail appropriately.
+     */
+    resolution?: {
+      /**
+       * Width in pixels.
+       */
+      width: number;
+      /**
+       * Height in pixels.
+       */
+      height: number;
+      [k: string]: unknown;
+    };
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^v_.*".
+     */
+    [k: `v_${string}`]: unknown;
+  }[];
+  /**
    * This interface was referenced by `HttpsOgrafEbuIoV1SpecificationJsonSchemasGraphicsSchemaJson`'s JSON-Schema definition
    * via the `patternProperty` "^v_.*".
    */


### PR DESCRIPTION
Each entry has file (required, path to image) and optionally resolution (object with width and height in pixels). Allowed image formats: PNG, JPG, GIF, webp.

Why resolution instead of ratio:
We use resolution (width × height) instead of a predefined ratio enum (e.g. 16by9, 9by16) so that UIs get actual pixel dimensions and can derive the aspect ratio when needed (e.g. width/height). Multiple thumbnails in different resolutions are supported directly, and the schema stays flexible without a fixed set of ratio strings.