### PR TITLE
Add engine version requirements to renderRequirements (Issue#25)

### DIFF
--- a/v1/specification/docs/Specification.md
+++ b/v1/specification/docs/Specification.md
@@ -155,6 +155,7 @@ The RenderRequirement object contains the following fields:
 | resolution.height | NumberConstraint |          |         | Specifies renderer height resolution requirement. |
 | frameRate         | NumberConstraint |          |         | Specifies renderer frameRate requirement. |
 | accessToPublicInternet | BooleanConstraint |          |    | Specifies requirement on whether the renderer has access to the public internet or not. |
+| engine                 | EngineRequirement[] |        |    | Array of minimum version requirements for the rendering engine |
 
 ##### NumberConstraint
 

--- a/v1/specification/json-schemas/graphics/schema.json
+++ b/v1/specification/json-schemas/graphics/schema.json
@@ -104,8 +104,32 @@
                     "accessToPublicInternet": {
                         "description": "If set, specifies requirement on whether the renderer has access to the public internet or not.",
                         "$ref": "https://ograf.ebu.io/v1/specification/json-schemas/lib/constraints/boolean.json"
+                    },
+                    "engine": {
+                        "description": "Minimum required version(s) of the rendering engine. At least one listed engine requirement should be satisfied by the renderer (e.g. type CEF with version.min 139).",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Identifier of the rendering engine (e.g. CEF, Gecko). Vendor-specific types are allowed."
+                                },
+                                "version": {
+                                    "type": "object",
+                                    "description": "Minimum engine version",
+                                    "properties": {
+                                        "min": {
+                                            "type": "string",
+                                            "description": "Minimum required version. Format is engine-specific (e.g. CEF branch number as string \"139\", or semver \"120.0.5\")."
+                                        }
+                                    },
+                                    "required": ["min"]
+                                }
+                            },
+                            "required": ["type", "version"]
+                        }
                     }
-
                 },
                 "patternProperties": {
                     "^v_.*": {}

--- a/v1/typescript-definitions/src/generated/graphics-manifest.ts
+++ b/v1/typescript-definitions/src/generated/graphics-manifest.ts
@@ -524,6 +524,26 @@ export interface HttpsOgrafEbuIoV1SpecificationJsonSchemasGraphicsSchemaJson {
     frameRate?: HttpsOgrafEbuIoV1SpecificationJsonSchemasLibConstraintsNumberJson1;
     accessToPublicInternet?: HttpsOgrafEbuIoV1SpecificationJsonSchemasLibConstraintsBooleanJson;
     /**
+     * Minimum required version(s) of the rendering engine. At least one listed engine requirement should be satisfied by the renderer (e.g. type CEF with version.min 139).
+     */
+    engine?: {
+      /**
+       * Identifier of the rendering engine (e.g. CEF, Gecko). Vendor-specific types are allowed.
+       */
+      type: string;
+      /**
+       * Minimum engine version; CEF uses branch number (e.g. 139), other engines use their own scheme.
+       */
+      version: {
+        /**
+         * Minimum required version. Format is engine-specific (e.g. CEF branch number as string "139", or semver "120.0.5"). Comparison semantics are defined by the renderer for the given engine type.
+         */
+        min: string;
+        [k: string]: unknown;
+      };
+      [k: string]: unknown;
+    }[];
+    /**
      * This interface was referenced by `undefined`'s JSON-Schema definition
      * via the `patternProperty` "^v_.*".
      */


### PR DESCRIPTION
Adds an optional engine property to renderRequirements: a list of requirements for the rendering engine (e.g. CEF, Gecko) with a minimum required version (version.min). min is intentionally defined as a string so different version formats (CEF, Chromium, WebKit, etc.) are supported.