### PR TITLE
feat(gdd): add file list GDD types (Issue ebu#23)

### DIFF
--- a/v1/specification/json-schemas/gdd/README.md
+++ b/v1/specification/json-schemas/gdd/README.md
@@ -252,6 +252,43 @@ Lets the user pick an image file from disk
 
 Example data: `"C:\images\myImage.jpg"` or `"folder/myImage.png"`
 
+### File list
+
+Lets the user select a file from a list of files scanned from a folder.
+
+```typescript
+{
+  "type": "string",
+  "gddType": "file-list",
+  "gddOptions": {
+    "folder": "files", // [Required, String] Folder path or URI to scan. Relative paths are resolved relative to the manifest/base folder.
+    "extensions": ["jpg", "txt"] // [Optional, Array of strings] Limit which files can be selected by the user.
+  }
+}
+```
+
+Example data: `"files/myImage.jpg"` or `"files/myFile.txt"`
+
+### File list multiple
+
+Lets the user select multiple files from a list of files scanned from a folder.
+
+```typescript
+{
+  "type": "array",
+  "items": {
+    "type": "string"
+  },
+  "gddType": "file-list-multiple",
+  "gddOptions": {
+    "folder": "files", // [Required, String] Folder path or URI to scan. Relative paths are resolved relative to the manifest/base folder.
+    "extensions": ["jpg", "txt"] // [Optional, Array of strings] Limit which files can be selected by the user.
+  }
+}
+```
+
+Example data: `["files/myImage.jpg", "files/myFile.txt"]`
+
 ### Select
 
 Lets the user select from a limited number of options (this is often done from a dropdown menu).

--- a/v1/specification/json-schemas/gdd/gdd-types.json
+++ b/v1/specification/json-schemas/gdd/gdd-types.json
@@ -79,6 +79,73 @@
     },
     {
       "if": {
+        "properties": { "gddType": { "const": "file-list" } },
+        "required": ["gddType"]
+      },
+      "then": {
+        "properties": {
+          "type": {
+            "const": "string"
+          },
+          "gddOptions": {
+            "type": "object",
+            "properties": {
+              "folder": {
+                "type": "string"
+              },
+              "extensions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["folder"]
+          }
+        },
+        "required": ["gddOptions"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "gddType": { "const": "file-list-multiple" } },
+        "required": ["gddType"]
+      },
+      "then": {
+        "properties": {
+          "type": {
+            "const": "array"
+          },
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "string"
+              }
+            },
+            "required": ["type"]
+          },
+          "gddOptions": {
+            "type": "object",
+            "properties": {
+              "folder": {
+                "type": "string"
+              },
+              "extensions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["folder"]
+          }
+        },
+        "required": ["gddOptions", "items"]
+      }
+    },
+    {
+      "if": {
         "properties": { "gddType": { "const": "select" } },
         "required": ["gddType"]
       },


### PR DESCRIPTION
Adds two GDD types for selecting files from a dynamically scanned folder.

`file-list` represents a single selected file path, while `file-list-multiple` represents an array of selected file paths. Both types use `gddOptions.folder` to define the folder to scan and optionally support `gddOptions.extensions` to filter selectable files.

Also updates the GDD documentation with examples for both new types.

Closes #23.