### PR TITLE
feat(gdd): add select-multiple GDD type (Issue ebu#37)

### DIFF
--- a/v1/specification/json-schemas/gdd/README.md
+++ b/v1/specification/json-schemas/gdd/README.md
@@ -297,6 +297,60 @@ Please note that the `type` for this can be either of `"string"`, `"integer"` or
 
 Example data: `"one"`, `1` or `1.2`
 
+### Select multiple
+
+Lets the user select multiple options from a limited number of options.
+
+Please note that the `items.type` for this can be either of `"string"`, `"integer"` or `"number"`.
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "string",
+    "enum": ["one", "two", "three"]
+  },
+  "gddType": "select-multiple",
+  "gddOptions": {
+    "labels": {
+      "one": "Label for one",
+      "two": "Label for two",
+      "three": "Label for three"
+    }
+  }
+}
+```
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "integer",
+    "enum": [1, 2, 3]
+  },
+  "gddType": "select-multiple",
+  "gddOptions": {
+    "labels": { "1": "Small", "2": "Medium", "3": "Large" }
+  }
+}
+```
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "number",
+    "enum": [1.2, 3.5, 9.0]
+  },
+  "gddType": "select-multiple",
+  "gddOptions": {
+    "labels": { "1.2": "Small", "3.5": "Medium", "9.0": "Large" }
+  }
+}
+```
+
+Example data: `["one", "three"]`, `[1, 3]` or `[1.2, 9.0]`
+
 ### Color - RRGGBB
 
 Let's the user pick a color.

--- a/v1/specification/json-schemas/gdd/gdd-types.json
+++ b/v1/specification/json-schemas/gdd/gdd-types.json
@@ -195,6 +195,161 @@
     },
     {
       "if": {
+        "properties": { "gddType": { "const": "select-multiple" } },
+        "required": ["gddType"]
+      },
+      "then": {
+        "properties": {
+          "type": {
+            "const": "array"
+          },
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": ["string", "number", "integer"]
+              },
+              "enum": {
+                "type": "array"
+              }
+            },
+            "required": ["type", "enum"]
+          },
+          "gddOptions": {
+            "type": "object",
+            "properties": {},
+            "required": ["labels"]
+          }
+        },
+        "required": ["gddOptions", "items"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "gddType": { "const": "select-multiple" },
+          "items": {
+            "properties": {
+              "type": { "const": "string" }
+            },
+            "required": ["type"]
+          }
+        },
+        "required": ["gddType", "items"]
+      },
+      "then": {
+        "properties": {
+          "items": {
+            "type": "object",
+            "properties": {
+              "enum": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "gddOptions": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "gddType": { "const": "select-multiple" },
+          "items": {
+            "properties": {
+              "type": { "const": "integer" }
+            },
+            "required": ["type"]
+          }
+        },
+        "required": ["gddType", "items"]
+      },
+      "then": {
+        "properties": {
+          "items": {
+            "type": "object",
+            "properties": {
+              "enum": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "gddOptions": {
+            "type": "object",
+            "properties": {
+              "labels": {
+                "type": "object",
+                "propertyNames": {
+                  "pattern": "^[0-9]+$"
+                },
+                "patternProperties": {
+                  ".": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "gddType": { "const": "select-multiple" },
+          "items": {
+            "properties": {
+              "type": { "const": "number" }
+            },
+            "required": ["type"]
+          }
+        },
+        "required": ["gddType", "items"]
+      },
+      "then": {
+        "properties": {
+          "items": {
+            "type": "object",
+            "properties": {
+              "enum": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "gddOptions": {
+            "type": "object",
+            "properties": {
+              "labels": {
+                "type": "object",
+                "propertyNames": {
+                  "pattern": "^[0-9,.]+$"
+                },
+                "patternProperties": {
+                  ".": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
         "properties": { "gddType": { "const": "color-rrggbb" } },
         "required": ["gddType"]
       },


### PR DESCRIPTION
Adds a `select-multiple` GDD type for selecting zero, one, or multiple values from a fixed list of options.

`select-multiple` uses `type: "array"` and supports string, integer, and number values through `items.type`. The available options are defined in `items.enum`, so each selected array item can be validated against the allowed values.

This intentionally differs slightly from the issue examples, which show `enum` on the top-level schema. Since the field value is an array, this PR places the enum on `items.enum` to match JSON Schema semantics.

Closes #37.