### PR TITLE
docs(api): clarify Server API path prefixes (Issue #51)

### DIFF
--- a/v1/specification/docs/Specification_Server_API.md
+++ b/v1/specification/docs/Specification_Server_API.md
@@ -20,6 +20,15 @@ The OGraf Server API is defined as an [OpenAPI](https://www.openapis.org/) defin
 
 ## Additional notes
 
+### Base URL and path prefixes
+
+A Server MAY expose the OGraf Server API under any base URL and path prefix.
+All paths defined in the OpenAPI document are relative to that base URL.
+
+For example, if the base URL is `https://example.com/my/prefix/ograf/v1`, the OpenAPI path `/graphics` is available at `https://example.com/my/prefix/ograf/v1/graphics`.
+
+The `/ograf/v1` path prefix used in examples is allowed, but not required.
+
 ### Security (optional)
 
 * The current version of the Server API doesn't specify any security measures.


### PR DESCRIPTION
Clarifies that OGraf Server API endpoints may be exposed under any base URL or path prefix.

The OpenAPI paths remain relative to the server's base URL. 
This does not introduce a required `/ograf/v1` prefix or a new API versioning policy.

Closes #51.