### PR TITLE
fix(spec): custom actions documentation does not match the schema

### DIFF
--- a/v1/specification/docs/Specification.md
+++ b/v1/specification/docs/Specification.md
@@ -155,8 +155,8 @@ an exact `step` match, then a fallback step duration without `step`, then the ac
 #### Custom actions
 
 A custom action is an action that is specific for a particular Graphic. It is a mechanism to support any action
-a Graphic can execute. The Manifest file defines the custom actions by means of the `actions` field. It represents
-a Map where the keys correspond to the id of the custom action and the values are `Action` objects. The `Action` object
+a Graphic can execute. The Manifest file defines the custom actions by means of the `customActions` field. It is an
+array of `Action` objects, each carrying the id of the custom action in its own `id` field. The `Action` object
 supports the following fields:
 
 | Field       | Type   | Required | Default | Description                                               |
@@ -164,7 +164,7 @@ supports the following fields:
 | id          | string |    X     |         | The identity of the action. The id must be unique within the graphic.                               |
 | name        | string |    X     |         | The name of the action (for use in GUIs).                 |
 | description | string |          |         | A longer description of the action.                       |
-| schema      | object |          |         | The JSON schema definition for the payload of the action. |
+| schema      | object |          |         | The JSON schema definition for the payload of the action. Set to `null` when the action takes no parameters. |
 
 #### RenderRequirements
 
@@ -385,15 +385,15 @@ customAction: (
 ) => Promise<ReturnPayload | undefined>;
 ```
 The `customAction()` function is called by the Renderer to invoke a custom action on the Graphic. The `id` field MUST
-correspond to an `id` of an Action that is defined in the Manifest file, inside the `actions` field. The schema for the
+correspond to an `id` of an Action that is defined in the Manifest file, inside the `customActions` field. The schema for the
 `payload` field is the described in the corresponding Action inside the Manifest file. The returned Promise MUST
 resolve when the action is executed.
 
-The `skipAnimation` field indicates whether the Graphic should disappear with or without animation.
+The `skipAnimation` field indicates whether the Graphic should perform the action with or without animation.
 When not provided, the `skipAnimation` field defaults to `false`. The Graphic MUST skip the animation when
 `skipAnimation` is set to `true`.
 
-The returned Promise MUST resolve after the execution of the update.
+The returned Promise MUST resolve after the execution of the action.
 The point in time when the Promise is resolved SHOULD indicate that the graphic is ready to execute another action.
 Typically, it could be when a graphic has finished an animation of the action.
 


### PR DESCRIPTION
These came up while working through the v1 spec for an implementation. Each one is a
place where the prose and the JSON schemas told me different things and I had to go to
the schemas to find out which to follow, so I am reporting them together.

The custom actions documentation does not match the Manifest schema. Two of these
mismatches produce a Manifest that fails validation if the prose is followed
literally; the rest are wording carried over from neighbouring sections.

I checked the two validation claims below with ajv against the schemas in
`v1/specification/json-schemas`, rather than by reading alone.

### `customActions` is an array, not a map

Line 159 describes the field as "a Map where the keys correspond to the id of the
custom action and the values are `Action` objects". In `graphics/schema.json`,
`customActions` is `"type": "array"` with `Action` items, and `Action` declares `id`
as a required property. Line 70 of this same document already says `Action[]`, "An
array of `Action` objects".

A Manifest written in the map form that line 159 describes is rejected with
`must be array`. The array form validates.

### The field is named `customActions`, not `actions`

Lines 158 and 388 both refer to an `actions` field. The Manifest has no such
property. Its properties are `$schema`, `id`, `version`, `main`, `name`,
`description`, `author`, `customActions`, `actionDurations`, `supportsRealTime`,
`supportsNonRealTime`, `stepCount`, `schema`, `renderRequirements` and `thumbnails`.

Since the schema sets `additionalProperties: false`, a Manifest that uses the name
`actions` is not merely unconventional, it is rejected with `must NOT have additional
properties`.

### An Action's `schema` may be null

Line 167 gives the type of the Action `schema` field as `object`. `lib/action.json`
declares it as `oneOf` an object or null, and its own description says "If the action
does not require any parameters, set this to null". The field table does not mention
that, so a reader working from the table would not know the null case exists.

I put the null case in the description column rather than the type column, because
every other type cell in this document is a bare type name and the document never
escapes a pipe inside a table. If you would rather the type column carried it, say so
and I will change it there instead.

### Two lines in `customAction()` describe a different action

Each action section describes `skipAnimation` with the verb of its own action:
"transition" for `playAction()` at line 297, "disappear" for `stopAction()` at line
346, "update" for `updateAction()` at line 368. Line 392 gives `customAction()` the
`stopAction()` wording, "should disappear", which does not describe an arbitrary
custom action.

Line 396 reads "The returned Promise MUST resolve after the execution of the update",
matching `updateAction()` at line 372. The next paragraph of the same section, at line
398, was already adapted to "an animation of the action", which suggests a line was
missed rather than an intentional cross-reference.

### What changed

Six lines, all in the custom actions material. `actions` becomes `customActions` in
both places, the map description becomes an array description, the Action `schema`
row gains the null case, "should disappear" becomes "should perform the action", and
"the execution of the update" becomes "the execution of the action". No other section
is touched.

### Left alone

Lines 389 and 390 already require the Promise to "resolve when the action is
executed", so line 396 restates the same rule. Removing that duplication is an
editorial decision rather than a correction, and it overlaps with the ground the
`fix/specification-actions` branch was covering, so I have left it as it stands.

### Related

The same pass through the spec produced two other things, listed here in case it is
easier to look at them together:

* #80 corrects the Manifest `schema` field description, which names a method that does
  not exist and omits `load()`.
* On #79 I asked whether the Server API section means to grant the Server explicit
  permission to validate `params.data`, or would rather stay silent on that and only
  cover what happens when data does not conform.

This is the last of the three, so nothing further is queued behind it.
